### PR TITLE
Increase income exclusion limit from $200 to $5000

### DIFF
--- a/RFIA.md
+++ b/RFIA.md
@@ -300,7 +300,7 @@ Sec.809.Advisory Committee on Financial Innovation.
 
 "(b) Limitation.—
 
-"(1) In general.—The amount of gain or loss excluded from gross income under subsection (a) with respect to a sale or exchange shall not exceed $200.
+"(1) In general.—The amount of gain or loss excluded from gross income under subsection (a) with respect to a sale or exchange shall not exceed $5,000.
 
 "(2) Aggregation rule.—For purposes of this subsection, all sales or exchanges which are part of the same transaction (or a series of related transactions) shall be treated as one sale or exchange.
 


### PR DESCRIPTION
I increased the income exclusion limit from $200 to $5,000. This increased limit is to accomodate the use of cryptocurrency as a medium of exchange for common daily/weekly/monthly transactions without requiring burdensome record-keeping. This will allow for free market competition so that cryptocurrencies can lower the cost, increase the speed, and improve the user experience for financial transactions. It's important that cryptocurrencies such as Bitcoin can compete on a level playing field with traditional fiat payment systems (e.g., Visa/MasterCard/American Express/Discover/Venmo/PayPal/ACH) that do not burden consumers with tracking cost basis and profit/loss for common transactions such as buying food/groceries/gas, or making rent/mortgage/car/insurance payments. For example, the $5,000 exclusion limit would accomodate people living in expensive cities such as Manhattan or San Francisco to pay their monthly rent (which can easily be ~$5,000) without burdensome recordkeeping, thereby enabling innovation and eliminating friction in commerce/payments/financial transactions.